### PR TITLE
added secondary sort by createDate in wishServiceImpl

### DIFF
--- a/backend/src/main/java/ru/iteco/fmh/controller/WishesController.java
+++ b/backend/src/main/java/ru/iteco/fmh/controller/WishesController.java
@@ -50,7 +50,7 @@ public class WishesController {
                 @RequestParam(defaultValue = "8") @Min(value = 1) @Max(value = 200) int elements,
             @ApiParam (required = false, name = "status", value = "[IN_PROGRESS, CANCELLED, OPEN, EXECUTED]")
                 @RequestParam(name = "status", required = false) List<Status>  status,
-            @ApiParam (required = false, name = "createDate", value = "Сортировка по дате исполнения")
+            @ApiParam (required = false, name = "planExecuteDate", value = "Сортировка по дате исполнения")
                 @RequestParam(defaultValue = "true") boolean planExecuteDate) {
 
         return ResponseEntity.ok(wishService.getWishes(pages, elements, status, planExecuteDate));

--- a/backend/src/main/java/ru/iteco/fmh/service/wish/WishServiceImpl.java
+++ b/backend/src/main/java/ru/iteco/fmh/service/wish/WishServiceImpl.java
@@ -43,8 +43,8 @@ public class WishServiceImpl implements WishService {
         Page<Wish> list;
 
         Pageable pageableList = planExecuteDate
-                ? PageRequest.of(pages, elements, Sort.by("planExecuteDate"))
-                : PageRequest.of(pages, elements, Sort.by("planExecuteDate").descending());
+                ? PageRequest.of(pages, elements, Sort.by("planExecuteDate").and(Sort.by("createDate").descending()))
+                : PageRequest.of(pages, elements, Sort.by("createDate").descending());
 
         if (status == null || status.isEmpty()) {
             list = wishRepository.findAllByStatusInAndDeletedIsFalse(List.of(OPEN, IN_PROGRESS), pageableList);

--- a/backend/src/test/java/ru/iteco/fmh/service/WishServiceTest.java
+++ b/backend/src/test/java/ru/iteco/fmh/service/WishServiceTest.java
@@ -76,7 +76,7 @@ public class WishServiceTest {
         List<WishDto> expected = wishList.stream().map(wish -> conversionService.convert(wish, WishDto.class))
                 .collect(Collectors.toList());
 
-        Pageable pageableList = PageRequest.of(0, 8, Sort.by("planExecuteDate"));
+        Pageable pageableList = PageRequest.of(0, 8, Sort.by("planExecuteDate").and(Sort.by("createDate").descending()));
         Page<Wish> pageableResult = new PageImpl<>(wishList, pageableList, 8);
         when(wishRepository.findAllByStatusInAndDeletedIsFalse(List.of(OPEN, IN_PROGRESS), pageableList))
                 .thenReturn(pageableResult);


### PR DESCRIPTION
По умолчанию сортировка происходит согласно сценарию 2 https://pmhproject.myjetbrains.com/youtrack/articles/pmh-A-40/06-Prosby Просьбы отсортированы по полям «Плановая дата» и «Дата создания» (Множественная сортировка: Плановая дата - первичная сортировка, по возрастанию, Дата создания - вторичная, по убыванию). При отключении сортировки по плановой дате, просьбы сортируются по убыванию даты создания.