### PR TITLE
fmh_back71 Добавить метод получения информации о пользователе для админа

### DIFF
--- a/backend/src/main/java/ru/iteco/fmh/controller/UsersController.java
+++ b/backend/src/main/java/ru/iteco/fmh/controller/UsersController.java
@@ -1,6 +1,13 @@
 package ru.iteco.fmh.controller;
 
+import io.swagger.v3.oas.annotations.Parameter;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import ru.iteco.fmh.dto.user.UserInfoDto;
 import ru.iteco.fmh.dto.user.UserShortInfoDto;
 import ru.iteco.fmh.service.user.UserService;
 import ru.iteco.fmh.service.verification.token.VerificationTokenService;
@@ -8,10 +15,6 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.access.annotation.Secured;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 
@@ -32,6 +35,14 @@ public class UsersController {
     @GetMapping
     public List<UserShortInfoDto> getAllUsers() {
         return userService.getAllUsers();
+    }
+
+    @Secured("ROLE_ADMINISTRATOR")
+    @Operation(summary = "получение информации о пользователе по id")
+    @GetMapping("/{userId}")
+    public UserInfoDto getUserInfo(@Parameter (description = "Идентификатор пользователя", required = true)
+                                       @PathVariable("userId") int userId) {
+        return userService.getUserInfo(userId);
     }
 
     @Operation(summary = "Подтверждение Email пользователя")

--- a/backend/src/main/java/ru/iteco/fmh/converter/user/UserRoleClaimShortToUserRoleClaim.java
+++ b/backend/src/main/java/ru/iteco/fmh/converter/user/UserRoleClaimShortToUserRoleClaim.java
@@ -4,9 +4,7 @@ import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.stereotype.Component;
-import ru.iteco.fmh.dao.repository.RoleRepository;
 import ru.iteco.fmh.dto.user.UserRoleClaimShort;
-import ru.iteco.fmh.model.user.Role;
 import ru.iteco.fmh.model.user.UserRoleClaim;
 
 /**
@@ -16,15 +14,10 @@ import ru.iteco.fmh.model.user.UserRoleClaim;
 @Component
 public class UserRoleClaimShortToUserRoleClaim implements Converter<UserRoleClaimShort, UserRoleClaim> {
 
-    private final RoleRepository roleRepository;
-
     @Override
     public UserRoleClaim convert(@NonNull UserRoleClaimShort claimDto) {
-        Role role = roleRepository.findRoleById(claimDto.getRoleId());
-
         return UserRoleClaim.builder()
                 .userId(claimDto.getUserId())
-                .role(role)
                 .status(claimDto.getStatus())
                 .build();
     }

--- a/backend/src/main/java/ru/iteco/fmh/converter/user/UserRoleClaimShortToUserRoleClaim.java
+++ b/backend/src/main/java/ru/iteco/fmh/converter/user/UserRoleClaimShortToUserRoleClaim.java
@@ -2,10 +2,11 @@ package ru.iteco.fmh.converter.user;
 
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.BeanUtils;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.stereotype.Component;
+import ru.iteco.fmh.dao.repository.RoleRepository;
 import ru.iteco.fmh.dto.user.UserRoleClaimShort;
+import ru.iteco.fmh.model.user.Role;
 import ru.iteco.fmh.model.user.UserRoleClaim;
 
 /**
@@ -15,10 +16,16 @@ import ru.iteco.fmh.model.user.UserRoleClaim;
 @Component
 public class UserRoleClaimShortToUserRoleClaim implements Converter<UserRoleClaimShort, UserRoleClaim> {
 
+    private final RoleRepository roleRepository;
+
     @Override
     public UserRoleClaim convert(@NonNull UserRoleClaimShort claimDto) {
-        var claim = new UserRoleClaim();
-        BeanUtils.copyProperties(claimDto, claim);
-        return claim;
+        Role role = roleRepository.findRoleById(claimDto.getRoleId());
+
+        return UserRoleClaim.builder()
+                .userId(claimDto.getUserId())
+                .role(role)
+                .status(claimDto.getStatus())
+                .build();
     }
 }

--- a/backend/src/main/java/ru/iteco/fmh/converter/user/UserRoleClaimToUserRoleClaimDtoConverter.java
+++ b/backend/src/main/java/ru/iteco/fmh/converter/user/UserRoleClaimToUserRoleClaimDtoConverter.java
@@ -3,7 +3,6 @@ package ru.iteco.fmh.converter.user;
 import lombok.RequiredArgsConstructor;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.stereotype.Component;
-import ru.iteco.fmh.dao.repository.RoleRepository;
 import ru.iteco.fmh.dto.user.UserRoleClaimDto;
 import ru.iteco.fmh.model.user.UserRoleClaim;
 
@@ -14,14 +13,13 @@ import ru.iteco.fmh.model.user.UserRoleClaim;
 @Component
 @RequiredArgsConstructor
 public class UserRoleClaimToUserRoleClaimDtoConverter implements Converter<UserRoleClaim, UserRoleClaimDto> {
-    RoleRepository roleRepository;
 
     @Override
     public UserRoleClaimDto convert(UserRoleClaim source) {
-        UserRoleClaimDto userRoleClaimDto = new UserRoleClaimDto();
-        userRoleClaimDto.setId(source.getId());
-        userRoleClaimDto.setCreatedAt(source.getCreatedAt());
-        userRoleClaimDto.setStatus(source.getStatus());
-        return userRoleClaimDto;
+        return UserRoleClaimDto.builder()
+                .id(source.getId())
+                .createdAt(source.getCreatedAt())
+                .status(source.getStatus())
+                .build();
     }
 }

--- a/backend/src/main/java/ru/iteco/fmh/converter/user/UserRoleClaimToUserRoleClaimDtoConverter.java
+++ b/backend/src/main/java/ru/iteco/fmh/converter/user/UserRoleClaimToUserRoleClaimDtoConverter.java
@@ -1,0 +1,27 @@
+package ru.iteco.fmh.converter.user;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.stereotype.Component;
+import ru.iteco.fmh.dao.repository.RoleRepository;
+import ru.iteco.fmh.dto.user.UserRoleClaimDto;
+import ru.iteco.fmh.model.user.UserRoleClaim;
+
+/**
+ * конвертер из {@link ru.iteco.fmh.model.user.UserRoleClaim} в {@link ru.iteco.fmh.dto.user.UserRoleClaimDto}
+ * //для «Управление пользователями» (Для UserInfoDto)
+ */
+@Component
+@RequiredArgsConstructor
+public class UserRoleClaimToUserRoleClaimDtoConverter implements Converter<UserRoleClaim, UserRoleClaimDto> {
+    RoleRepository roleRepository;
+
+    @Override
+    public UserRoleClaimDto convert(UserRoleClaim source) {
+        UserRoleClaimDto userRoleClaimDto = new UserRoleClaimDto();
+        userRoleClaimDto.setId(source.getId());
+        userRoleClaimDto.setCreatedAt(source.getCreatedAt());
+        userRoleClaimDto.setStatus(source.getStatus());
+        return userRoleClaimDto;
+    }
+}

--- a/backend/src/main/java/ru/iteco/fmh/converter/user/UserRoleClaimToUserRoleClaimDtoConverter.java
+++ b/backend/src/main/java/ru/iteco/fmh/converter/user/UserRoleClaimToUserRoleClaimDtoConverter.java
@@ -18,8 +18,9 @@ public class UserRoleClaimToUserRoleClaimDtoConverter implements Converter<UserR
     public UserRoleClaimDto convert(UserRoleClaim source) {
         return UserRoleClaimDto.builder()
                 .id(source.getId())
-                .createdAt(source.getCreatedAt())
+                .role(source.getRole().getName())
                 .status(source.getStatus())
+                .createdAt(source.getCreatedAt())
                 .build();
     }
 }

--- a/backend/src/main/java/ru/iteco/fmh/converter/user/UserToUserInfoDtoConverter.java
+++ b/backend/src/main/java/ru/iteco/fmh/converter/user/UserToUserInfoDtoConverter.java
@@ -1,0 +1,40 @@
+package ru.iteco.fmh.converter.user;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.stereotype.Component;
+import ru.iteco.fmh.dao.repository.UserRoleClaimRepository;
+import ru.iteco.fmh.dto.user.UserEmailDto;
+import ru.iteco.fmh.dto.user.UserInfoDto;
+import ru.iteco.fmh.model.user.Role;
+import ru.iteco.fmh.model.user.User;
+import lombok.NonNull;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * конвертер из {@link User} в {@link UserInfoDto}//для «Управление пользователями» (Для userInfoDto)
+ */
+@Component
+@RequiredArgsConstructor
+public class UserToUserInfoDtoConverter implements Converter<User, UserInfoDto> {
+    UserRoleClaimRepository userRoleClaimRepository;
+    UserRoleClaimToUserRoleClaimDtoConverter userRoleClaimToUserRoleClaimDtoConverter;
+
+    @Override
+    public UserInfoDto convert(@NonNull User source) {
+        Set<Role> roles = source.getUserRoles();
+
+        UserInfoDto userInfoDto = new UserInfoDto();
+        userInfoDto.setId(source.getId());
+        userInfoDto.setFirstName(source.getFirstName());
+        userInfoDto.setLastName(source.getLastName());
+        userInfoDto.setMiddleName(source.getMiddleName());
+        userInfoDto.setAdmin(roles.stream().anyMatch(n -> n.getName().equals("ROLE_ADMINISTRATOR")));
+        userInfoDto.setEmail(UserEmailDto.builder().name(source.getEmail()).isConfirmed(source.isEmailConfirmed()).build());
+        userInfoDto.setRoles(roles.stream().map(Role::getName).collect(Collectors.toSet()));
+
+        return userInfoDto;
+    }
+}

--- a/backend/src/main/java/ru/iteco/fmh/converter/user/UserToUserInfoDtoConverter.java
+++ b/backend/src/main/java/ru/iteco/fmh/converter/user/UserToUserInfoDtoConverter.java
@@ -25,11 +25,12 @@ public class UserToUserInfoDtoConverter implements Converter<User, UserInfoDto> 
         Set<Role> roles = source.getUserRoles();
         return UserInfoDto.builder()
                 .id(source.getId())
-                .firstName(source.getFirstName())
-                .lastName(source.getLastName())
-                .middleName(source.getMiddleName())
+                .firstName(source.getProfile().getFirstName())
+                .lastName(source.getProfile().getLastName())
+                .middleName(source.getProfile().getMiddleName())
                 .isAdmin(Util.isAdmin(source))
-                .email(UserEmailDto.builder().name(source.getEmail()).isConfirmed(source.isEmailConfirmed()).build())
+                .email(UserEmailDto.builder().name(source.getProfile().getEmail())
+                        .isConfirmed(source.getProfile().isEmailConfirmed()).build())
                 .roles(roles.stream().map(Role::getName).collect(Collectors.toSet()))
                 .build();
     }

--- a/backend/src/main/java/ru/iteco/fmh/converter/user/UserToUserInfoDtoConverter.java
+++ b/backend/src/main/java/ru/iteco/fmh/converter/user/UserToUserInfoDtoConverter.java
@@ -3,7 +3,7 @@ package ru.iteco.fmh.converter.user;
 import lombok.RequiredArgsConstructor;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.stereotype.Component;
-import ru.iteco.fmh.dao.repository.UserRoleClaimRepository;
+import ru.iteco.fmh.Util;
 import ru.iteco.fmh.dto.user.UserEmailDto;
 import ru.iteco.fmh.dto.user.UserInfoDto;
 import ru.iteco.fmh.model.user.Role;
@@ -19,22 +19,18 @@ import java.util.stream.Collectors;
 @Component
 @RequiredArgsConstructor
 public class UserToUserInfoDtoConverter implements Converter<User, UserInfoDto> {
-    UserRoleClaimRepository userRoleClaimRepository;
-    UserRoleClaimToUserRoleClaimDtoConverter userRoleClaimToUserRoleClaimDtoConverter;
 
     @Override
     public UserInfoDto convert(@NonNull User source) {
         Set<Role> roles = source.getUserRoles();
-
-        UserInfoDto userInfoDto = new UserInfoDto();
-        userInfoDto.setId(source.getId());
-        userInfoDto.setFirstName(source.getFirstName());
-        userInfoDto.setLastName(source.getLastName());
-        userInfoDto.setMiddleName(source.getMiddleName());
-        userInfoDto.setAdmin(roles.stream().anyMatch(n -> n.getName().equals("ROLE_ADMINISTRATOR")));
-        userInfoDto.setEmail(UserEmailDto.builder().name(source.getEmail()).isConfirmed(source.isEmailConfirmed()).build());
-        userInfoDto.setRoles(roles.stream().map(Role::getName).collect(Collectors.toSet()));
-
-        return userInfoDto;
+        return UserInfoDto.builder()
+                .id(source.getId())
+                .firstName(source.getFirstName())
+                .lastName(source.getLastName())
+                .middleName(source.getMiddleName())
+                .isAdmin(Util.isAdmin(source))
+                .email(UserEmailDto.builder().name(source.getEmail()).isConfirmed(source.isEmailConfirmed()).build())
+                .roles(roles.stream().map(Role::getName).collect(Collectors.toSet()))
+                .build();
     }
 }

--- a/backend/src/main/java/ru/iteco/fmh/dao/repository/RoleRepository.java
+++ b/backend/src/main/java/ru/iteco/fmh/dao/repository/RoleRepository.java
@@ -14,4 +14,6 @@ public interface RoleRepository extends JpaRepository<Role, Integer> {
     Optional<Role> findRoleByName(String roleName);
 
     List<Role> findAllByNeedConfirmIsTrueAndNameIn(List<String> rolesName);
+
+    Role findRoleById(Integer id);
 }

--- a/backend/src/main/java/ru/iteco/fmh/dao/repository/UserRoleClaimRepository.java
+++ b/backend/src/main/java/ru/iteco/fmh/dao/repository/UserRoleClaimRepository.java
@@ -2,12 +2,16 @@ package ru.iteco.fmh.dao.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
+import ru.iteco.fmh.model.user.RoleClaimStatus;
 import ru.iteco.fmh.model.user.UserRoleClaim;
 
 import java.util.List;
 
+import java.util.Collection;
+
 @Repository
 public interface UserRoleClaimRepository extends JpaRepository<UserRoleClaim, Integer> {
     List<UserRoleClaim> findByUserId(Integer userId);
-    UserRoleClaim findUserRoleClaimByUserId(Integer id);
+
+    UserRoleClaim findFirstByUserIdAndStatusIn(Integer id, Collection<RoleClaimStatus> statuses);
 }

--- a/backend/src/main/java/ru/iteco/fmh/dao/repository/UserRoleClaimRepository.java
+++ b/backend/src/main/java/ru/iteco/fmh/dao/repository/UserRoleClaimRepository.java
@@ -6,4 +6,5 @@ import ru.iteco.fmh.model.user.UserRoleClaim;
 
 @Repository
 public interface UserRoleClaimRepository extends JpaRepository<UserRoleClaim, Integer> {
+    UserRoleClaim findUserRoleClaimByUserId(Integer id);
 }

--- a/backend/src/main/java/ru/iteco/fmh/dto/user/UserInfoDto.java
+++ b/backend/src/main/java/ru/iteco/fmh/dto/user/UserInfoDto.java
@@ -1,0 +1,49 @@
+package ru.iteco.fmh.dto.user;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.experimental.FieldDefaults;
+
+import java.util.Set;
+
+import static lombok.AccessLevel.PRIVATE;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "Информация по пользователю")
+@Builder
+@Data
+@FieldDefaults(level = PRIVATE)
+public class UserInfoDto {
+    @Schema(name = "id", description = "Идентификатор пользователя")
+    Integer id;
+
+    @Schema(name = "firstName", description = "Имя")
+    String firstName;
+
+    @Schema(name = "lastName", description = "Фамилия")
+    String lastName;
+
+    @Schema(name = "middleName", description = "Отчество")
+    String middleName;
+
+    @Schema(name = "isAdmin", description = "Признак администратора")
+    boolean isAdmin;
+
+    @Schema(name = "email", description = "Электронная почта")
+    UserEmailDto email;
+
+    @Schema(name = "roles", description = "Множество ролей")
+    Set<String> roles;
+
+    @Schema(name = "isConfirmed", description = "Признак подтверждения пользователя")
+    boolean isConfirmed;
+
+    @Schema(name = "userRoleClaim", description = "Заявка на роль пользователя, средняя")
+    UserRoleClaimDto userRoleClaim;
+
+
+}

--- a/backend/src/main/java/ru/iteco/fmh/dto/user/UserRoleClaimDto.java
+++ b/backend/src/main/java/ru/iteco/fmh/dto/user/UserRoleClaimDto.java
@@ -1,0 +1,36 @@
+package ru.iteco.fmh.dto.user;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.experimental.FieldDefaults;
+import ru.iteco.fmh.model.user.RoleClaimStatus;
+
+import java.time.Instant;
+
+import static lombok.AccessLevel.PRIVATE;
+
+@JsonFormat
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "Заявка на роль пользователя, средняя")
+@Builder
+@Data
+@FieldDefaults(level = PRIVATE)
+public class UserRoleClaimDto {
+
+    @Schema(name = "id", description = "Идентификатор пользователя")
+    Integer id;
+
+    @Schema(name = "role", description = "Название роли")
+    String role;
+
+    @Schema(name = "status", description = "Статус заявки на роль пользователя")
+    RoleClaimStatus status;
+
+    @Schema(name = "createdAt", description = "Дата создания заявки на роль")
+    Instant createdAt;
+}

--- a/backend/src/main/java/ru/iteco/fmh/service/user/UserService.java
+++ b/backend/src/main/java/ru/iteco/fmh/service/user/UserService.java
@@ -1,5 +1,6 @@
 package ru.iteco.fmh.service.user;
 
+import ru.iteco.fmh.dto.user.UserInfoDto;
 import ru.iteco.fmh.dto.user.UserShortInfoDto;
 import ru.iteco.fmh.model.user.User;
 
@@ -20,4 +21,10 @@ public interface UserService {
      *  Возвращает активного пользователя, если он есть
      */
     public User getActiveUserByLogin(String login);
+
+    /**
+     *
+     *  Возвращает информацию по пользователю, если он есть
+     */
+    UserInfoDto getUserInfo(Integer id);
 }

--- a/backend/src/main/java/ru/iteco/fmh/service/user/UserServiceImpl.java
+++ b/backend/src/main/java/ru/iteco/fmh/service/user/UserServiceImpl.java
@@ -77,10 +77,8 @@ public class UserServiceImpl implements UserService {
 
         UserRoleClaim userRoleClaim = userRoleClaimRepository.findFirstByUserIdAndStatusIn(id,
                 List.of(RoleClaimStatus.NEW, RoleClaimStatus.REJECTED));
-        UserRoleClaimDto userRoleClaimDto;
         if (userRoleClaim != null) {
-            userRoleClaimDto = conversionService.convert(userRoleClaim, UserRoleClaimDto.class);
-            userRoleClaimDto.setRole(userRoleClaim.getRole().getName());
+            UserRoleClaimDto userRoleClaimDto = conversionService.convert(userRoleClaim, UserRoleClaimDto.class);
             userInfoDto.setUserRoleClaim(userRoleClaimDto);
             userInfoDto.setConfirmed(false);
         } else {

--- a/backend/src/main/java/ru/iteco/fmh/service/user/UserServiceImpl.java
+++ b/backend/src/main/java/ru/iteco/fmh/service/user/UserServiceImpl.java
@@ -13,7 +13,7 @@ import ru.iteco.fmh.dto.user.UserShortInfoDto;
 import ru.iteco.fmh.exceptions.IncorrectDataException;
 import ru.iteco.fmh.exceptions.InvalidLoginException;
 import ru.iteco.fmh.exceptions.NotFoundException;
-import ru.iteco.fmh.model.user.Role;
+import ru.iteco.fmh.model.user.RoleClaimStatus;
 import ru.iteco.fmh.model.user.User;
 import ru.iteco.fmh.model.user.UserRoleClaim;
 
@@ -31,7 +31,6 @@ public class UserServiceImpl implements UserService {
     private final RoleRepository roleRepository;
 
     private final ConversionService conversionService;
-    private final UserRoleClaimRepository userRoleClaimRepository;
 
 
     @Override
@@ -76,18 +75,19 @@ public class UserServiceImpl implements UserService {
         }
 
         UserInfoDto userInfoDto = conversionService.convert(user, UserInfoDto.class);
-        assert userInfoDto != null;
 
+        UserRoleClaim userRoleClaim = userRoleClaimRepository.findFirstByUserIdAndStatusIn(id,
+                List.of(RoleClaimStatus.NEW, RoleClaimStatus.REJECTED));
         UserRoleClaimDto userRoleClaimDto;
-        UserRoleClaim userRoleClaim = userRoleClaimRepository.findUserRoleClaimByUserId(id);
         if (userRoleClaim != null) {
             userRoleClaimDto = conversionService.convert(userRoleClaim, UserRoleClaimDto.class);
-            assert userRoleClaimDto != null;
-            userRoleClaimDto.setRole(roleRepository.findById(userRoleClaim.getRoleId()).map(Role::getName).orElse(null));
+            userRoleClaimDto.setRole(userRoleClaim.getRole().getName());
             userInfoDto.setUserRoleClaim(userRoleClaimDto);
+            userInfoDto.setConfirmed(false);
         } else {
             userInfoDto.setConfirmed(true);
         }
+
         return userInfoDto;
     }
 }

--- a/backend/src/main/resources/application-dev.yml
+++ b/backend/src/main/resources/application-dev.yml
@@ -6,7 +6,7 @@ spring:
   jpa:
     open-in-view: false
     database-platform: org.hibernate.dialect.PostgreSQL95Dialect
-    show-sql: false
+    show-sql: true
     properties:
       hibernate:
         jdbc:

--- a/backend/src/main/resources/application-dev.yml
+++ b/backend/src/main/resources/application-dev.yml
@@ -6,7 +6,7 @@ spring:
   jpa:
     open-in-view: false
     database-platform: org.hibernate.dialect.PostgreSQL95Dialect
-    show-sql: true
+    show-sql: false
     properties:
       hibernate:
         jdbc:

--- a/backend/src/main/resources/db/migration/test/R__initialization_data.sql
+++ b/backend/src/main/resources/db/migration/test/R__initialization_data.sql
@@ -118,3 +118,7 @@ values (1, 'document1', 'description1', false, 'NEW', '01/01/2023', '/documents/
        (11, 'document11', 'description11', false, 'PUBLISHED', '03/02/2023', '/documents/document11.doc', 4),
        (12, 'document12', 'description12', false, 'PUBLISHED', '03/02/2023', '/documents/document12.doc', 4),
        (13, 'document13', 'description13', false, 'PUBLISHED', '03/02/2023', '/documents/document13.doc', 4);
+
+insert into user_role_claim(id, user_id, role_id, status, created_at, updated_at)
+values (1, 3, 1, 'NEW', '03/02/2023', '03/02/2023'),
+       (2, 4, 4, 'CONFIRMED', '01/02/2023', '03/02/2023');

--- a/backend/src/test/java/ru/iteco/fmh/TestUtils.java
+++ b/backend/src/test/java/ru/iteco/fmh/TestUtils.java
@@ -13,7 +13,6 @@ import ru.iteco.fmh.dto.user.UserDtoIdFio;
 import ru.iteco.fmh.dto.wish.WishCommentDto;
 import ru.iteco.fmh.dto.wish.WishCreationRequest;
 import ru.iteco.fmh.dto.wish.WishDto;
-import ru.iteco.fmh.model.Block;
 import ru.iteco.fmh.model.NurseStation;
 import ru.iteco.fmh.model.Patient;
 import ru.iteco.fmh.model.PatientStatus;
@@ -67,9 +66,11 @@ public class TestUtils {
 
     public static Role getRole(String roleName) {
         return Role.builder()
-                .id(Integer.valueOf(getNumeric(2)))
+                .id(1)
                 .name(roleName)
                 .deleted(false)
+                .description(getAlphabeticString())
+                .needConfirm(true)
                 .build();
     }
 

--- a/backend/src/test/java/ru/iteco/fmh/converter/UserRoleClaimShortToUserRoleClaimTest.java
+++ b/backend/src/test/java/ru/iteco/fmh/converter/UserRoleClaimShortToUserRoleClaimTest.java
@@ -2,32 +2,58 @@ package ru.iteco.fmh.converter;
 
 import org.junit.jupiter.api.Test;
 import ru.iteco.fmh.converter.user.UserRoleClaimShortToUserRoleClaim;
+import ru.iteco.fmh.dao.repository.RoleRepository;
 import ru.iteco.fmh.dto.user.UserRoleClaimShort;
+import ru.iteco.fmh.model.user.Role;
 import ru.iteco.fmh.model.user.RoleClaimStatus;
-
-import java.util.Random;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-class UserRoleClaimShortToUserRoleClaimTest {
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
-    UserRoleClaimShortToUserRoleClaim target = new UserRoleClaimShortToUserRoleClaim();
+import static ru.iteco.fmh.TestUtils.*;
+
+class UserRoleClaimShortToUserRoleClaimTest {
+    RoleRepository roleRepository = mock(RoleRepository.class);
+
+    UserRoleClaimShortToUserRoleClaim target = new UserRoleClaimShortToUserRoleClaim(roleRepository);
 
     @Test
     void convert() {
-        Random random = new Random();
+        var testDTO = new UserRoleClaimShort(1, 1, RoleClaimStatus.NEW);
+        Role role = getRole("ROLE_ADMINISTRATOR");
 
-        var testDTO = new UserRoleClaimShort(random.nextInt(5000), random.nextInt(5000), RoleClaimStatus.NEW);
+        when(roleRepository.findRoleById(any())).thenReturn(role);
 
         var actual = target.convert(testDTO);
 
         assertAll(
-                () -> assertEquals(testDTO.getUserId(), actual.getUserId()),
-                () -> assertEquals(testDTO.getRoleId(), actual.getRole().getId()),
-                () -> assertEquals(testDTO.getStatus(), actual.getStatus()),
-                () -> assertNull(actual.getId()),
-                () -> assertNull(actual.getCreatedAt()),
-                () -> assertNull(actual.getUpdatedAt())
+                () -> {
+                    assert actual != null;
+                    assertEquals(testDTO.getUserId(), actual.getUserId());
+                },
+                () -> {
+                    assert actual != null;
+                    assertEquals(testDTO.getRoleId(), actual.getRole().getId());
+                },
+                () -> {
+                    assert actual != null;
+                    assertEquals(testDTO.getStatus(), actual.getStatus());
+                },
+                () -> {
+                    assert actual != null;
+                    assertNull(actual.getId());
+                },
+                () -> {
+                    assert actual != null;
+                    assertNull(actual.getCreatedAt());
+                },
+                () -> {
+                    assert actual != null;
+                    assertNull(actual.getUpdatedAt());
+                }
         );
     }
 }

--- a/backend/src/test/java/ru/iteco/fmh/converter/UserRoleClaimShortToUserRoleClaimTest.java
+++ b/backend/src/test/java/ru/iteco/fmh/converter/UserRoleClaimShortToUserRoleClaimTest.java
@@ -18,7 +18,7 @@ import static ru.iteco.fmh.TestUtils.*;
 class UserRoleClaimShortToUserRoleClaimTest {
     RoleRepository roleRepository = mock(RoleRepository.class);
 
-    UserRoleClaimShortToUserRoleClaim target = new UserRoleClaimShortToUserRoleClaim(roleRepository);
+    UserRoleClaimShortToUserRoleClaim target = new UserRoleClaimShortToUserRoleClaim();
 
     @Test
     void convert() {
@@ -29,31 +29,16 @@ class UserRoleClaimShortToUserRoleClaimTest {
 
         var actual = target.convert(testDTO);
 
+        assert actual != null;
+        actual.setRole(roleRepository.findRoleById(testDTO.getRoleId()));
+
         assertAll(
-                () -> {
-                    assert actual != null;
-                    assertEquals(testDTO.getUserId(), actual.getUserId());
-                },
-                () -> {
-                    assert actual != null;
-                    assertEquals(testDTO.getRoleId(), actual.getRole().getId());
-                },
-                () -> {
-                    assert actual != null;
-                    assertEquals(testDTO.getStatus(), actual.getStatus());
-                },
-                () -> {
-                    assert actual != null;
-                    assertNull(actual.getId());
-                },
-                () -> {
-                    assert actual != null;
-                    assertNull(actual.getCreatedAt());
-                },
-                () -> {
-                    assert actual != null;
-                    assertNull(actual.getUpdatedAt());
-                }
+                () -> assertEquals(testDTO.getUserId(), actual.getUserId()),
+                () -> assertEquals(testDTO.getRoleId(), actual.getRole().getId()),
+                () -> assertEquals(testDTO.getStatus(), actual.getStatus()),
+                () -> assertNull(actual.getId()),
+                () -> assertNull(actual.getCreatedAt()),
+                () -> assertNull(actual.getUpdatedAt())
         );
     }
 }

--- a/cucumber-tests/pom.xml
+++ b/cucumber-tests/pom.xml
@@ -68,12 +68,6 @@
             <version>5.9.1</version>
             <scope>test</scope>
         </dependency>
-        <!--<dependency>
-            <groupId>ru.i-teco.backend</groupId>
-            <artifactId>fmh-backend</artifactId>
-            <version>0.0.1-SNAPSHOT</version>
-            <scope>compile</scope>
-        </dependency>-->
 
     </dependencies>
 

--- a/cucumber-tests/pom.xml
+++ b/cucumber-tests/pom.xml
@@ -68,6 +68,12 @@
             <version>5.9.1</version>
             <scope>test</scope>
         </dependency>
+        <!--<dependency>
+            <groupId>ru.i-teco.backend</groupId>
+            <artifactId>fmh-backend</artifactId>
+            <version>0.0.1-SNAPSHOT</version>
+            <scope>compile</scope>
+        </dependency>-->
 
     </dependencies>
 

--- a/cucumber-tests/src/main/java/ru/iteco/cucumber/model/user/RoleClaimStatus.java
+++ b/cucumber-tests/src/main/java/ru/iteco/cucumber/model/user/RoleClaimStatus.java
@@ -1,0 +1,15 @@
+package ru.iteco.cucumber.model.user;
+
+/**
+ * Enum для статуса заявки на роль
+ */
+public enum RoleClaimStatus {
+
+    // Новая
+    NEW,
+    // Подтверждена
+    CONFIRMED,
+    // Отклонена
+    REJECTED
+
+}

--- a/cucumber-tests/src/main/java/ru/iteco/cucumber/model/user/UserInfoDto.java
+++ b/cucumber-tests/src/main/java/ru/iteco/cucumber/model/user/UserInfoDto.java
@@ -1,0 +1,35 @@
+package ru.iteco.cucumber.model.user;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.*;
+import ru.iteco.cucumber.model.UserEmailDto;
+
+import java.util.Set;
+
+@Builder
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class UserInfoDto {
+
+    @JsonProperty("id")
+    private Integer id;
+    @JsonProperty("firstName")
+    private String firstName;
+    @JsonProperty("lastName")
+    private String lastName;
+    @JsonProperty("middleName")
+    private String middleName;
+    @JsonProperty("admin")
+    private boolean isAdmin;
+    @JsonProperty("email")
+    private UserEmailDto email;
+    @JsonProperty("roles")
+    private Set<String> roles;
+    @JsonProperty("confirmed")
+    private boolean isConfirmed;
+    @JsonProperty("userRoleClaim")
+    private UserRoleClaimDto userRoleClaim;
+
+}

--- a/cucumber-tests/src/main/java/ru/iteco/cucumber/model/user/UserRoleClaimDto.java
+++ b/cucumber-tests/src/main/java/ru/iteco/cucumber/model/user/UserRoleClaimDto.java
@@ -1,0 +1,22 @@
+package ru.iteco.cucumber.model.user;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.*;
+
+import java.util.Date;
+
+@Builder
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class UserRoleClaimDto {
+    @JsonProperty("id")
+    Integer id;
+    @JsonProperty("role")
+    String role;
+    @JsonProperty("status")
+    RoleClaimStatus status;
+    @JsonProperty("createdAt")
+    Date createdAt;
+}

--- a/cucumber-tests/src/test/java/cucumber/UserInfoSteps.java
+++ b/cucumber-tests/src/test/java/cucumber/UserInfoSteps.java
@@ -1,0 +1,34 @@
+package cucumber;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import cucumber.utils.BackendUrls;
+import cucumber.utils.RestTemplateUtil;
+import io.cucumber.java.en.When;
+import lombok.RequiredArgsConstructor;
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+import ru.iteco.cucumber.model.user.UserInfoDto;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@Slf4j
+@RequiredArgsConstructor
+public class UserInfoSteps {
+    private final RestTemplateUtil restTemplateUtil = new RestTemplateUtil();
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    private final UserCommonSteps userCommonSteps;
+
+    @SneakyThrows
+    @When("Просматривает информацию о пользователе по {string}")
+    public void getUserInfo(String userId){
+        String jwt = userCommonSteps.getJwt();
+        String responseBody = restTemplateUtil
+                .getRq(jwt, BackendUrls.USERS_BASE_URL + "/" + userId)
+                .getBody();
+        assertNotNull(responseBody);
+        UserInfoDto userInfoDto = objectMapper.readValue(responseBody, UserInfoDto.class);
+        assertNotNull(userInfoDto);
+        log.info("USER INFO: {}", userInfoDto);
+    }
+}

--- a/cucumber-tests/src/test/java/cucumber/utils/BackendUrls.java
+++ b/cucumber-tests/src/test/java/cucumber/utils/BackendUrls.java
@@ -8,4 +8,5 @@ public class BackendUrls {
     public static final String NEWS_BASE_URL = "/news";
     public static final String DOCUMENTS_BASE_URL = "/documents";
     public static final String ADMIN_BASE_URL = "/admin";
+    public static final String USERS_BASE_URL = "/users";
 }

--- a/cucumber-tests/src/test/resources/cucumber/UserInfoSteps.feature
+++ b/cucumber-tests/src/test/resources/cucumber/UserInfoSteps.feature
@@ -1,0 +1,16 @@
+Feature: Сценарии использования справочником «Управление пользователями».
+  1. Аутентификация пользователя
+  2. Получение информации о пользователе по его идентификатору
+
+  Scenario Outline:
+    Given Пользователь вводит логин "<login>" и пароль "<password>"
+    When  Просматривает информацию о пользователе по "<userId>"
+    Then  Результат "<result>"
+
+    Examples:
+      | login   | password  | userId | result  |
+      | login1  | password1 | 1      | SUCCESS |
+      | login2  | password2 | 2      | SUCCESS |
+      | login1  | password1 | 3      | SUCCESS |
+      | login2  | password2 | 4      | SUCCESS |
+      | login5  | password5 | 5      | SUCCESS |


### PR DESCRIPTION
В контроллере ru.iteco.fmh.controller.UsersController добавить GET /{userId}

Метод доступен для роли админ

Создать новое дто UserInfoDto с полями:

id: Integer
firstName:String
lastName:String
middleName:String
isAdmin:Boolean
email:`UserEmailDto`
roles:List<String>
isConfirmed:boolean
userRoleClaim: UserRoleClaimDto
Создать дто UserRoleClaimDto:

id:Integer
role:String
status:RoleClaimStatus
createdAt: Instant
Создать конвертер UserToUserInfoDto, на вход получающий User и возвращающий сущность UserInfoDto. Важно! У пользователя может не быть UserRoleClaim. В этом случае проставляем isConfirmed = true, userRoleClaim = null

Создать новый метод в ru.iteco.fmh.service.user.UserService getUserInfo:

Ищем пользователя по id
Если не нашли то NotFoundException
возвращаем информацию о найденном пользователе через созданный конвертер